### PR TITLE
fix: correct Helm provider kubernetes block syntax

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -4,7 +4,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"  # Ensure this is pointing to your kubeconfig file
   }
 }


### PR DESCRIPTION
- Change kubernetes {} block to kubernetes = {} assignment
- Fixes Terraform error: 'Blocks of type kubernetes are not expected here'
- Enables successful deployment of Grafana monitoring stack
- Resolves compatibility issue with newer Terraform Helm provider versions